### PR TITLE
fix README set example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ console.log('original book 3', book3)
 operator.path = paths.book3;
 
 // overwrite book3 with book2
-operator.set(book2val)
+operator.overwrite(book2val)
 let book3Set = operator.value(); 
 
 console.log('original book 3', book3)


### PR DESCRIPTION
I wondered why my copy/paste test erred but your `demo.js` didn't!

Could there be further improvement for the doc, example, & API?  `overwrite` & `merge` seem alike (at least glancing at the docs & example).  Maybe they should all be merged into `merge`?  Or rename `overwrite` back into `set`, & [overload set](http://stackoverflow.com/questions/456177/function-overloading-in-javascript-best-practices)?